### PR TITLE
Add `zip_comment` attribute to streamer

### DIFF
--- a/lib/zip_tricks/streamer.rb
+++ b/lib/zip_tricks/streamer.rb
@@ -94,6 +94,8 @@ class ZipTricks::Streamer
 
   private_constant :DeflatedWriter, :StoredWriter, :STORED, :DEFLATED
 
+  attr_accessor :zip_comment
+
   # Creates a new Streamer on top of the given IO-ish object and yields it. Once the given block
   # returns, the Streamer will have it's `close` method called, which will write out the central
   # directory of the archive to the output.
@@ -119,6 +121,7 @@ class ZipTricks::Streamer
     @local_header_offsets = []
     @filenames_set = Set.new
     @writer = writer
+    @zip_comment = ZipTricks::ZipWriter.const_get('ZIP_TRICKS_COMMENT')
   end
 
   # Writes a part of a zip entry body (actual binary data of the entry) into the output stream.
@@ -343,7 +346,8 @@ class ZipTricks::Streamer
     @writer.write_end_of_central_directory(io: @out,
                                            start_of_central_directory_location: cdir_starts_at,
                                            central_directory_size: cdir_size,
-                                           num_files_in_archive: @files.length)
+                                           num_files_in_archive: @files.length,
+                                           comment: zip_comment)
 
     # Clear the files so that GC will not have to trace all the way to here to deallocate them
     @files.clear

--- a/spec/zip_tricks/streamer_spec.rb
+++ b/spec/zip_tricks/streamer_spec.rb
@@ -495,4 +495,16 @@ describe ZipTricks::Streamer do
                                   'file_one (1).jpg', 'file_one (2).jpg', 'My.Super.file.txt.zip',
                                   'My.Super.file (1).txt.zip'])
   end
+
+  it 'uses `zip_comment` attribute when writing the end of central directory' do
+    fake_writer = double('Writer').as_null_object
+
+    expect(fake_writer).to receive(:write_end_of_central_directory) { |**kwargs|
+      expect(kwargs[:comment]).to eq('Zip Comment')
+    }
+
+    described_class.open(StringIO.new, writer: fake_writer) do |zip|
+      zip.zip_comment = 'Zip Comment'
+    end
+  end
 end


### PR DESCRIPTION
## Description
We want to be able to set different comment for each file being created by the streamer.

### Changes
Added a `zip_comment` attribute to the streamer (set to the default `ZIP_TRICKS_COMMENT` on initialize to make sure  byte sizes are preserved for all specs that read them) and send that to the writer when writing the end of central repository record.
