### PR TITLE
Allow to specify modification date when adding entries to streamer

### DIFF
--- a/spec/zip_tricks/streamer_spec.rb
+++ b/spec/zip_tricks/streamer_spec.rb
@@ -507,4 +507,22 @@ describe ZipTricks::Streamer do
       zip.zip_comment = 'Zip Comment'
     end
   end
+
+  it 'writes the specified modification date' do
+    fake_writer = double('Writer').as_null_object
+
+    expect(fake_writer).to receive(:write_local_file_header) { |**kwargs|
+      expect(kwargs[:mtime]).to eq(Time.new('2018-01-01 00:00:00'))
+    }.exactly(3).times
+
+    described_class.open(StringIO.new, writer: fake_writer) do |zip|
+      zip.write_stored_file('stored.txt', modification_date: Time.new('2018-01-01 00:00:00')) do |sink|
+        sink << 'stored'
+      end
+      zip.write_deflated_file('deflated.txt', modification_date: Time.new('2018-01-01 00:00:00')) do |sink|
+        sink << 'deflated'
+      end
+      zip.add_empty_directory(dirname: 'empty', modification_date: Time.new('2018-01-01 00:00:00'))
+    end
+  end
 end


### PR DESCRIPTION
## Description
We need a way to preserve modification dates when adding files and folders to the zip file.

### Changes
Added a keyword arg `modification_date` to all `add_*` and `write_*` streamer methods and send that to the writer when writing the local file header.
